### PR TITLE
:arrow_up: Bump to 2.0.1: compat with WordPress 7.0.1 and WooCommerce 10.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: webheadgmbh, mohammad425
 Tags: woocommerce, bulk price update, price adjustment, product management, scheduled rules
 Requires at least: 6.0
-Tested up to: 6.9
+Tested up to: 7.0.1
 Requires PHP: 7.4
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -93,6 +93,10 @@ No, all features of this plugin are fully accessible for free. There is no pro v
 4. Settings
 
 == Changelog ==
+
+= 2.0.1 =
+* Tested with WordPress 7.0.1 and WooCommerce 10.9.
+* Fix: Prevent a fatal error during uninstall on PHP 8 caused by undefined cache-key constants.
 
 = 2.0.0 =
 * Added Scheduled Rules feature for automated rule-based price updates.

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,14 +9,18 @@
 # Prevent direct file access
 defined('ABSPATH') || exit;
 
-// Clean up before uninstalling this plugin
+// Clean up before uninstalling this plugin.
+// Note: the plugin's main file is not loaded during uninstall, so the
+// WEBHEAD_BULK_PRICE_UPDATE_* constants are unavailable here. We use the literal
+// cache-key values (mirrors the constants defined in wh-bulk-price-update.php) to
+// avoid a fatal "undefined constant" error on PHP 8+.
 delete_option('wh_bulk_price_update_block_size');
 delete_option('wh_bulk_price_update_preview_block_size');
 delete_option('wh_bulk_price_update_time_limit');
 delete_option('wh_bulk_price_update_cog_meta_key');
-delete_transient(WEBHEAD_BULK_PRICE_UPDATE_BLOG_POST_CACHE_KEY . '_en');
-delete_transient(WEBHEAD_BULK_PRICE_UPDATE_BLOG_POST_CACHE_KEY . '_de');
-delete_transient(WEBHEAD_BULK_PRICE_UPDATE_PLUGINS_CACHE_KEY);
+delete_transient('wh_blog_posts_en');
+delete_transient('wh_blog_posts_de');
+delete_transient('wh_plugins');
 delete_option('wh_bulk_price_update_db_version');
 
 // Drop price rule tables

--- a/wh-bulk-price-update.php
+++ b/wh-bulk-price-update.php
@@ -3,14 +3,14 @@
  * Plugin Name: Bulk Price Update for WooCommerce
  * Plugin URI: https://github.com/webhead-GmbH/wh-bulk-price-update-for-woocommerce
  * Description: Easily update WooCommerce product prices in bulk and automate recurring price changes with Scheduled Rules.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: webhead GmbH
  * Author URI: https://webhead.at
  * Text Domain: wh-bulk-price-update-for-woocommerce
  * Domain Path: /languages
  * Requires Plugins: woocommerce
  * WC requires at least: 7.1.0
- * WC tested up to: 10.5
+ * WC tested up to: 10.9
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * License: GNU General Public License v3.0
@@ -28,7 +28,7 @@ if (!function_exists('is_plugin_inactive')) include_once(ABSPATH . 'wp-admin/inc
 function webhead_bulk_price_update_setup_constants()
 {
     if (!defined('WEBHEAD_BULK_PRICE_UPDATE_VERSION'))
-        define('WEBHEAD_BULK_PRICE_UPDATE_VERSION', '2.0.0');
+        define('WEBHEAD_BULK_PRICE_UPDATE_VERSION', '2.0.1');
 
     if (!defined('WEBHEAD_BULK_PRICE_UPDATE_PLUGIN_DIR'))
         define('WEBHEAD_BULK_PRICE_UPDATE_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
… 10.9

- Set "WC tested up to" to 10.9 and "Tested up to" to 7.0.1
- Bump version/stable tag to 2.0.1 with changelog entry
- Fix undefined cache-key constants in uninstall.php that caused a fatal error on PHP 8 (main plugin file is not loaded during uninstall)